### PR TITLE
Allow user to specify res directory

### DIFF
--- a/src/com/konifar/material_icon_generator/IconModel.java
+++ b/src/com/konifar/material_icon_generator/IconModel.java
@@ -25,12 +25,12 @@ public class IconModel {
     private static final String PATH_DRAWABLE_PREFIX = "drawable-";
     private static final String UNDERBAR = "_";
     private static final String PNG_SUFFIX = ".png";
-    private static final String COPY_DIR = "/app/src/main/res";
 
     private String iconName;
     private String color;
     private String dp;
     private String fileName;
+    private String resDir;
 
     private boolean mdpi;
     private boolean hdpi;
@@ -42,6 +42,7 @@ public class IconModel {
                      String color,
                      String dp,
                      String fileName,
+                     String resDir,
                      boolean mdpi,
                      boolean hdpi,
                      boolean xhdpi,
@@ -51,6 +52,7 @@ public class IconModel {
         this.color = color.toLowerCase();
         this.dp = dp;
         this.fileName = fileName;
+        this.resDir = resDir;
         this.mdpi = mdpi;
         this.hdpi = hdpi;
         this.xhdpi = xhdpi;
@@ -97,9 +99,12 @@ public class IconModel {
     }
 
     public String getResourcePath(Project project) {
+        if (resDir.startsWith(project.getBasePath())) {
+            return resDir;
+        }
         StringBuilder sb = new StringBuilder();
         sb.append(project.getBasePath());
-        sb.append(COPY_DIR);
+        sb.append(resDir);
         return sb.toString();
     }
 
@@ -140,6 +145,10 @@ public class IconModel {
 
     public void setFileName(String fileName) {
         this.fileName = fileName;
+    }
+
+    public void setResDir(String resDir) {
+        this.resDir = resDir;
     }
 
     public void setMdpi(boolean mdpi) {
@@ -184,5 +193,9 @@ public class IconModel {
 
     public String getFileName() {
         return fileName;
+    }
+
+    public String getResDir() {
+        return resDir;
     }
 }

--- a/src/com/konifar/material_icon_generator/MaterialDesignIconGenerateDialog.form
+++ b/src/com/konifar/material_icon_generator/MaterialDesignIconGenerateDialog.form
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.konifar.material_icon_generator.MaterialDesignIconGenerateDialog">
-  <grid id="204ea" binding="panelMain" layout-manager="GridLayoutManager" row-count="9" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="204ea" binding="panelMain" layout-manager="GridLayoutManager" row-count="10" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="8" left="8" bottom="8" right="8"/>
     <constraints>
-      <xy x="65" y="54" width="790" height="313"/>
+      <xy x="65" y="54" width="790" height="318"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -82,7 +82,7 @@
       </component>
       <component id="b403f" class="javax.swing.JCheckBox" binding="checkBoxMdpi">
         <constraints>
-          <grid row="4" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="5" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <selected value="true"/>
@@ -99,9 +99,27 @@
           <text value="Name: "/>
         </properties>
       </component>
+      <component id="a7e4f" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Res Directory:"/>
+        </properties>
+      </component>
+      <component id="fe45" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="resDirectoryName">
+        <constraints>
+          <grid row="4" column="2" row-span="1" col-span="2" vsize-policy="1" hsize-policy="0" anchor="8" fill="1" indent="0" use-parent-layout="false">
+            <minimum-size width="300" height="-1"/>
+            <preferred-size width="300" height="-1"/>
+            <maximum-size width="300" height="-1"/>
+          </grid>
+        </constraints>
+        <properties/>
+      </component>
       <component id="15334" class="javax.swing.JCheckBox" binding="checkBoxXhdpi">
         <constraints>
-          <grid row="5" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="6" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <selected value="true"/>
@@ -110,7 +128,7 @@
       </component>
       <component id="37d35" class="javax.swing.JCheckBox" binding="checkBoxXxhdpi">
         <constraints>
-          <grid row="5" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="6" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <selected value="true"/>
@@ -119,7 +137,7 @@
       </component>
       <component id="ba213" class="javax.swing.JCheckBox" binding="checkBoxXxxhdpi">
         <constraints>
-          <grid row="6" column="2" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="7" column="2" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="xxxhdpi"/>
@@ -127,7 +145,7 @@
       </component>
       <component id="7db49" class="javax.swing.JCheckBox" binding="checkBoxHdpi">
         <constraints>
-          <grid row="4" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="5" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <selected value="true"/>
@@ -136,7 +154,7 @@
       </component>
       <component id="619d6" class="javax.swing.JLabel" binding="imageLabel">
         <constraints>
-          <grid row="0" column="4" row-span="7" col-span="1" vsize-policy="2" hsize-policy="2" anchor="0" fill="3" indent="0" use-parent-layout="false">
+          <grid row="0" column="4" row-span="8" col-span="1" vsize-policy="2" hsize-policy="2" anchor="0" fill="3" indent="0" use-parent-layout="false">
             <minimum-size width="180" height="180"/>
           </grid>
         </constraints>
@@ -149,13 +167,13 @@
       </component>
       <component id="d27c2" class="javax.swing.JSeparator">
         <constraints>
-          <grid row="7" column="1" row-span="1" col-span="4" vsize-policy="6" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="8" column="1" row-span="1" col-span="4" vsize-policy="6" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
       </component>
       <grid id="f5f11" layout-manager="FlowLayout" hgap="5" vgap="5" flow-align="0">
         <constraints>
-          <grid row="8" column="1" row-span="1" col-span="3" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="9" column="1" row-span="1" col-span="3" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>


### PR DESCRIPTION
I've added an extra field that allows a user to specify where there res directory is. I wanted to use your plugin, but unfortunately the project I work on has a non standard structure.

Here is a screenshot of what it looks like now. ![New UI](https://www.dropbox.com/s/y1sthcjwb72ib5k/Screenshot%202015-02-23%2022.44.09.png?dl=1)

I've also modified the error message to give a little more information when an invalid directory is chosen. 
