### PR TITLE
Fix unsupported png format issue

### DIFF
--- a/src/com/konifar/material_icon_generator/MaterialDesignIconGenerateDialog.java
+++ b/src/com/konifar/material_icon_generator/MaterialDesignIconGenerateDialog.java
@@ -475,17 +475,28 @@ public class MaterialDesignIconGenerateDialog extends DialogWrapper {
 
         int width = image.getWidth();
         int height = image.getHeight();
+        boolean hasAlpha = image.getColorModel().hasAlpha();
 
         BufferedImage newImage = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
         WritableRaster raster = newImage.getRaster();
         for (int xx = 0; xx < width; xx++) {
             for (int yy = 0; yy < height; yy++) {
-                Color originalColor = new Color(image.getRGB(xx, yy), true);
+                int originalPixel = image.getRGB(xx, yy);
+                int originalAlpha;
+                if (hasAlpha) {
+                    originalAlpha = new Color(originalPixel, true).getAlpha();
+                } else {
+                    // Due to ImageIO's issue, `hasAlpha` is assigned `false` although PNG file has alpha channel.
+                    // Regarding PNG files of Material Icon, in this case, the file is 1bit depth binary(BLACK or WHITE).
+                    // Therefore BLACK is `alpha = 0` and WHITE is `alpha = 255`
+                    originalAlpha = originalPixel == 0xFF000000 ? 0 : 255;
+                }
+
                 int[] pixels = new int[4];
                 pixels[0] = color.getRed();
                 pixels[1] = color.getGreen();
                 pixels[2] = color.getBlue();
-                pixels[3] = combineAlpha(originalColor.getAlpha(), color.getAlpha());
+                pixels[3] = combineAlpha(originalAlpha, color.getAlpha());
                 raster.setPixel(xx, yy, pixels);
             }
         }


### PR DESCRIPTION
Fix #40 

My rough investigation found png file format difference and ImageIO's strange behavior, and I added a tiny workaround for this issue.
## Icon PNG File Format

PNG has several formats to optimize file size.
Following table shows **Bit Depth** and **Color Type** of `ic_add_white_<xx>dp.png` under
`src/com/konifar/material_icon_generator/icons/content/drawable-xxhdpi`

| File | 18dp | 24dp | 36dp | 48 dp |
| --- | --- | --- | --- | --- |
| Size | 54x54 | 72x72 | 108x108 | 144x144 |
| Bit Depth | 8 | 1 | 4 | 1 |
| Color Type | 4 | 0 | 3 | 0 |

Color Type 4 means _grayscale + alpha_
Color Type 3 means _indexed color with pallet_
Color Type 0 means _just grayscale_ (alpha information stored in tRNS chunk)

Please look `ic_add_white_24dp.png` and `ic_add_white_48dp.png`.
They have only two kind of pixels. `0x00FFFFFF` or `0xFF000000`.
## ImageIO behavior

All material icons have alpha channel, but it disappears for some files such as `ic_add_white_24dp` and `48dp`. `hasAlpha()` returns `false`.

I didn't check all of icons but I think this issue occurs in the file which has 0 color type.
## Workaround

I think there are three options to fix this issue.
1. Convert material icon png format using ffmpeg (or other good tool)
2. Use third party png library instead of ImageIO
3. Add tiny workaround

This PR realizes option 3 like this,

```
If getAlpha() returns false, check 0xFF000000 or not to calculate alpha value.
```
## Reference
- [Portable Network Graphics - Wikipedia, the free encyclopedia](https://en.wikipedia.org/wiki/Portable_Network_Graphics)
- [PNG Specification: Chunk Specifications](https://www.w3.org/TR/PNG-Chunks.html)
- [PNGビューアの表示テスト結果](http://www.piece-me.org/pngview/pngview.html)

Thanks for reading and sorry for my loooong explanation.... :bow: 
