### PR TITLE
Set default icon size to 24dp

### DIFF
--- a/src/main/java/com/konifar/material_icon_generator/MaterialDesignIconGenerateDialog.java
+++ b/src/main/java/com/konifar/material_icon_generator/MaterialDesignIconGenerateDialog.java
@@ -345,6 +345,8 @@ public class MaterialDesignIconGenerateDialog extends DialogWrapper {
     }
 
     private void initDpComboBox() {
+        comboBoxDp.setSelectedIndex(1);         // 24dp
+
         comboBoxDp.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent event) {


### PR DESCRIPTION
According to [Material Design guidelines](https://material.google.com/style/icons.html), system icons are 24dp
