### PR TITLE
Rename 'OK' and 'Cancel' buttons labels

### DIFF
--- a/src/main/java/com/konifar/material_icon_generator/MaterialDesignIconGenerateDialog.java
+++ b/src/main/java/com/konifar/material_icon_generator/MaterialDesignIconGenerateDialog.java
@@ -76,6 +76,8 @@ public class MaterialDesignIconGenerateDialog extends DialogWrapper {
     private static final String ERROR_SIZE_CHECK_EMPTY = "Please check icon size.";
     private static final String ERROR_RESOURCE_DIR_NOTHING_PREFIX = "Can not find resource dir: ";
     private static final String ERROR_CUSTOM_COLOR = "Can not parse custom color. Please provide color in hex format (#FFFFFF).";
+    private static final String OK_BUTTON_LABEL = "Generate";
+    private static final String CANCEL_BUTTON_LABEL = "Close";
 
     private static final String ICON_CONFIRM = "/icons/toggle/drawable-mdpi/ic_check_box_black_24dp.png";
     private static final String ICON_WARNING = "/icons/alert/drawable-mdpi/ic_error_black_24dp.png";
@@ -137,6 +139,9 @@ public class MaterialDesignIconGenerateDialog extends DialogWrapper {
         model.setIconAndFileName((String) comboBoxIcon.getSelectedItem());
         textFieldFileName.setText(model.getFileName());
         showIconPreview();
+
+        setOKButtonText(OK_BUTTON_LABEL);
+        setCancelButtonText(CANCEL_BUTTON_LABEL);
 
         init();
     }


### PR DESCRIPTION
I suggest renaming 'OK' and 'Cancel' buttons labels (in the main dialog), as they are not intuitive right now. They should name the actions which are really triggered by these buttons click:
- 'OK' -> 'Generate'
- 'Cancel' -> 'Close'

I would especially vote for renaming 'Cancel' button. After each successful icon generation user is navigated back to the main dialog. Only way to close it now is clicking 'Cancel', which is usually associated with resign action. In my opinion 'Close' would be much more intuitive here.